### PR TITLE
CR-11078 allowing post data with application/json requests

### DIFF
--- a/provider/views.py
+++ b/provider/views.py
@@ -551,6 +551,9 @@ class AccessToken(OAuthView, Mixin):
                 'error': 'invalid_request',
                 'error_description': _("A secure connection is required.")})
 
+        if request.content_type == 'application/json':
+             request.POST = json.loads(request.body)
+
         if not 'grant_type' in request.POST:
             return self.error_response({
                 'error': 'invalid_request',

--- a/provider/views.py
+++ b/provider/views.py
@@ -552,7 +552,7 @@ class AccessToken(OAuthView, Mixin):
                 'error_description': _("A secure connection is required.")})
 
         if request.content_type == 'application/json':
-             request.POST = json.loads(request.body)
+             request.POST = json.loads(request.body.decode('utf-8'))  # Py3 compatibility
 
         if not 'grant_type' in request.POST:
             return self.error_response({


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/CR-11078

**Description**
Allows application/json POST data to be sent to the oauth2 endpoints, so API clients don't have to hack their JSON data into */form-data layouts